### PR TITLE
Fix overlooked ruby3 keyword argument deprecation warning

### DIFF
--- a/lib/hanami/v1/validations.rb
+++ b/lib/hanami/v1/validations.rb
@@ -265,7 +265,7 @@ module Hanami
         # @api private
         def _build(options = {}, &blk)
           options = {build: false}.merge(options)
-          Rdy::Validation.__send__(_schema_type, options, &blk)
+          Rdy::Validation.__send__(_schema_type, **options, &blk)
         end
 
         # @since 0.6.0


### PR DESCRIPTION
# Backround

Our first ruby deprecation warnings removal run was done before we switched to Rdy. Now we call Rdy::Validation with deprecated syntax which will crash after updating to Ruby 3

# Design

Fix the deprecated method call.

# Impact

- Hanami controllers using application.
- No behaviour change.

# Caveats 
-

# Testing

- Tested by injecting it into Ruby 3 application.
